### PR TITLE
ignore whitespace before CHARS line in imported font files

### DIFF
--- a/src/bdfparser/bdfparser.py
+++ b/src/bdfparser/bdfparser.py
@@ -230,7 +230,9 @@ class Font(object):
     def __parse_glyph_count(self):
 
         if self.__curline_chars is None:
-            line = next(self.__f)
+            line = next(self.__f).strip()
+            while len(line) == 0:
+                line = next(self.__f).strip()
         else:
             line = self.__curline_chars
             self.__curline_chars = None


### PR DESCRIPTION
Some font files I am working with have a blank line between the `ENDPROPERTIES` and `CHARS` lines, eg [here](https://github.com/olikraus/u8g2/blob/master/tools/font/bdf/8x13.bdf).

This is breaking the `Font` import with the following:

```python
>>> from bdfparser import Font
>>> font = Font('8x13.bdf')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/owen/BDFPARSER/bdfparser.py", line 92, in __init__
    self.load_file_path(arg)
  File "/home/owen/BDFPARSER/bdfparser.py", line 104, in load_file_path
    self.load_file_obj(file_obj)
  File "/home/owen/BDFPARSER/bdfparser.py", line 115, in load_file_obj
    self.__parse_headers()
  File "/home/owen/BDFPARSER/bdfparser.py", line 146, in __parse_headers
    self.__parse_props()
  File "/home/owen/BDFPARSER/bdfparser.py", line 222, in __parse_props
    self.__parse_glyph_count()
  File "/home/owen/BDFPARSER/bdfparser.py", line 243, in __parse_glyph_count
    if kvlist[0] == 'CHARS':
       ~~~~~~^^^
IndexError: list index out of range
>>> 
```

The fix here will ignore any empty lines between `ENDPROPERTIES` and the `CHARS` lines.

The examples I have also have additional empty lines in other sections; but these do not seem to affect the rest of the import.

I'm guessing a better solution may be to strip all empty lines from the file at import, but I did not pursue this.